### PR TITLE
SDF -> WoT: Handle unreadable and unwritable properties

### DIFF
--- a/src/wot/tm_from_sdf.rs
+++ b/src/wot/tm_from_sdf.rs
@@ -258,8 +258,10 @@ fn convert_to_data_schema(sdf_property: &sdf::DataQualities) -> wot::DataSchema 
     } else if !writable && readable {
         write_only = None;
         read_only = Some(true);
+    } else if !writable && !readable {
+        write_only = Some(true);
+        read_only = Some(true);
     } else {
-        // TODO: How do you map a property that is neither writable nor readable?
         write_only = None;
         read_only = None;
     }


### PR DESCRIPTION
I was wondering a bit how to deal with properties that neither `readable` nor `writable` during the conversion. I got the suggestion from the JSON Schema community to set both `readOnly` and `writeOnly` to true in this case as the former prevents write operations while the latter is preventing read operations. 

While it is not an ideal solution (as `readOnly` and `writeOnly` are in general) I wanted to use this PR to disuss the approach before refactoring the whole section in the code. Maybe you could have a quick look on this issue, @cabo?