### PR TITLE
Make project usable as a library and refine CLI functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,10 +31,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "chrono"
@@ -52,6 +78,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,7 +112,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -107,6 +148,15 @@ name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ident_case"
@@ -228,6 +278,7 @@ dependencies = [
  "assert-json-diff",
  "chrono",
  "ciborium",
+ "clap",
  "regex",
  "serde",
  "serde_json",
@@ -291,6 +342,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -304,6 +361,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -351,6 +417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +439,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MIT"
 repository = "https://github.com/JKRhb/sdf-wot-converter"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ assert-json-diff = "2.0.1"
 ciborium = "0.1.0"
 regex = "1.5.4"
 url = "2.2.2"
+clap = "2.33.3"
 
 [dependencies.serde_with]
 version = "1.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jan Romann <jan.romann@uni-bremen.de>"]
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/JKRhb/sdf-wot-converter"
+exclude = [".github/**/*", "tests/**/*"]
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ license = "MIT"
 repository = "https://github.com/JKRhb/sdf-wot-converter"
 exclude = [".github/**/*", "tests/**/*"]
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "sdf-wot-converter-cli" # TODO: Revisit binary name
+path = "src/bin/cli.rs"
 
 [dependencies]
 serde_json = "1.0"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,13 +1,9 @@
-mod converter;
-mod sdf;
-mod wot;
+use sdf_wot_converter::{converter, sdf::definitions::SDFModel, wot::definitions::Thing};
 
-use sdf::definitions::SDFModel;
 use serde_json;
 use std::env;
 use std::fs;
 use url::Url;
-use wot::definitions::Thing;
 
 /// Reads a JSON file from a specified path, deserializes it to a supported data type,
 /// and returns a formatted `String` as a `Result`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod converter;
+pub mod sdf;
+pub mod wot;


### PR DESCRIPTION
So far the converter has only been usable as a compiled binary. This PR makes it also usable as a library that can be reused in other projects.