### PR TITLE
Move all read and write operations to the CLI

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -10,15 +10,17 @@ use crate::ConverterResult;
 /// # Examples
 ///
 /// ```rust
-/// use sdf_wot_converter::converter::print_sdf_definition_from_path;
+/// use sdf_wot_converter::converter::print_sdf_definition;
+/// use std::fs;
 ///
-/// print_sdf_definition_from_path("examples/sdf/example.sdf.json");
+/// let json_string = fs::read_to_string("examples/sdf/example.sdf.json").unwrap();
 ///
-/// assert!(print_sdf_definition_from_path("examples/sdf/example.sdf.json").is_ok());
-/// assert!(print_sdf_definition_from_path("foobar.json").is_err());
+/// let result = print_sdf_definition(json_string);
+///
+/// assert!(result.is_ok());
 /// ```
 pub fn print_sdf_definition(json_string: String) -> ConverterResult<()> {
-    ThingDescription::print_definition(json_string)
+    SDFModel::print_definition(json_string)
 }
 
 /// Deserializes a WoT TD definition, converts it back into a
@@ -27,12 +29,14 @@ pub fn print_sdf_definition(json_string: String) -> ConverterResult<()> {
 /// # Examples
 ///
 /// ```rust
-/// use sdf_wot_converter::converter::print_wot_td_definition_from_path;
+/// use sdf_wot_converter::converter::print_wot_td_definition;
+/// use std::fs;
 ///
-/// print_wot_td_definition_from_path("examples/wot/example.td.json");
+/// let json_string = fs::read_to_string("examples/wot/example.td.json").unwrap();
 ///
-/// assert!(print_wot_td_definition_from_path("examples/wot/example.td.json").is_ok());
-/// assert!(print_wot_td_definition_from_path("foobar.json").is_err());
+/// let result = print_wot_td_definition(json_string);
+///
+/// assert!(result.is_ok());
 /// ```
 pub fn print_wot_td_definition(json_string: String) -> ConverterResult<()> {
     ThingDescription::print_definition(json_string)
@@ -44,12 +48,14 @@ pub fn print_wot_td_definition(json_string: String) -> ConverterResult<()> {
 /// # Examples
 ///
 /// ```rust
-/// use sdf_wot_converter::converter::print_wot_tm_definition_from_path;
+/// use sdf_wot_converter::converter::print_wot_tm_definition;
+/// use std::fs;
 ///
-/// print_wot_tm_definition_from_path("examples/wot/example.tm.json");
+/// let json_string = fs::read_to_string("examples/wot/example.tm.json").unwrap();
 ///
-/// assert!(print_wot_tm_definition_from_path("examples/wot/example.tm.json").is_ok());
-/// assert!(print_wot_tm_definition_from_path("foobar.json").is_err());
+/// let result = print_wot_tm_definition(json_string);
+///
+/// assert!(result.is_ok());
 /// ```
 pub fn print_wot_tm_definition(json_string: String) -> ConverterResult<()> {
     ThingModel::print_definition(json_string)
@@ -110,7 +116,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sdf_to_wot() {
+    fn test_sdf_to_wot_tm() {
         let output = sdf_to_wot_tm(SDFModel::new_empty_model());
         assert!(output.is_ok());
     }

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -17,8 +17,8 @@ use crate::ConverterResult;
 /// assert!(print_sdf_definition_from_path("examples/sdf/example.sdf.json").is_ok());
 /// assert!(print_sdf_definition_from_path("foobar.json").is_err());
 /// ```
-pub fn print_sdf_definition_from_path(path: &str) -> ConverterResult<()> {
-    SDFModel::print_definition_from_path(path)
+pub fn print_sdf_definition(json_string: String) -> ConverterResult<()> {
+    ThingDescription::print_definition(json_string)
 }
 
 /// Deserializes a WoT TD definition, converts it back into a
@@ -34,8 +34,8 @@ pub fn print_sdf_definition_from_path(path: &str) -> ConverterResult<()> {
 /// assert!(print_wot_td_definition_from_path("examples/wot/example.td.json").is_ok());
 /// assert!(print_wot_td_definition_from_path("foobar.json").is_err());
 /// ```
-pub fn print_wot_td_definition_from_path(path: &str) -> ConverterResult<()> {
-    ThingDescription::print_definition_from_path(path)
+pub fn print_wot_td_definition(json_string: String) -> ConverterResult<()> {
+    ThingDescription::print_definition(json_string)
 }
 
 /// Deserializes a WoT TM definition, converts it back into a
@@ -51,12 +51,52 @@ pub fn print_wot_td_definition_from_path(path: &str) -> ConverterResult<()> {
 /// assert!(print_wot_tm_definition_from_path("examples/wot/example.tm.json").is_ok());
 /// assert!(print_wot_tm_definition_from_path("foobar.json").is_err());
 /// ```
-pub fn print_wot_tm_definition_from_path(path: &str) -> ConverterResult<()> {
-    ThingModel::print_definition_from_path(path)
+pub fn print_wot_tm_definition(json_string: String) -> ConverterResult<()> {
+    ThingModel::print_definition(json_string)
+}
+
+/// Deserializes an SDF Model JSON `String` and converts it into an WoT Thing Model
+/// JSON `String`.
+///
+/// # Examples
+///
+/// ```rust
+/// use sdf_wot_converter::converter::convert_sdf_to_wot_tm;
+/// use std::fs;
+///
+/// let json_string = fs::read_to_string("examples/sdf/example.sdf.json").unwrap();
+///
+/// let result = convert_sdf_to_wot_tm(json_string);
+/// assert!(result.is_ok());
+/// ```
+pub fn convert_sdf_to_wot_tm(json_string: String) -> ConverterResult<String> {
+    SDFModel::deserialize_json_string(json_string)
+        .and_then(sdf_to_wot_tm)
+        .and_then(|m| ThingModel::serialize_json(&m))
+}
+
+/// Deserializes a WoT Thing Model JSON `String` and converts it into an SDF Model
+/// JSON `String`.
+///
+/// # Examples
+///
+/// ```rust
+/// use sdf_wot_converter::converter::convert_sdf_to_wot_tm;
+/// use std::fs;
+///
+/// let json_string = fs::read_to_string("examples/sdf/example.sdf.json").unwrap();
+///
+/// let result = convert_sdf_to_wot_tm(json_string);
+/// assert!(result.is_ok());
+/// ```
+pub fn convert_wot_tm_to_sdf(json_string: String) -> ConverterResult<String> {
+    ThingModel::deserialize_json_string(json_string)
+        .and_then(wot_tm_to_sdf)
+        .and_then(|m| SDFModel::serialize_json(&m))
 }
 
 /// Converts an SDF model to a WoT Thing Model.
-fn sdf_to_wot(sdf_model: SDFModel) -> ConverterResult<ThingModel> {
+fn sdf_to_wot_tm(sdf_model: SDFModel) -> ConverterResult<ThingModel> {
     Ok(ThingModel::from(sdf_model))
 }
 
@@ -65,63 +105,13 @@ fn wot_tm_to_sdf(thing_model: ThingModel) -> ConverterResult<SDFModel> {
     Ok(SDFModel::from(thing_model))
 }
 
-/// Deserializes an SDF definition from a given file path and converts
-/// it into a WoT Thing Model.
-///
-/// # Examples
-///
-/// ```rust
-/// use sdf_wot_converter::converter::sdf_to_wot_from_path;
-///
-/// let result = sdf_to_wot_from_path("examples/sdf/example.sdf.json");
-/// assert!(result.is_ok());
-///
-/// assert!(sdf_to_wot_from_path("foobar.json").is_err());
-/// ```
-pub fn sdf_to_wot_from_path(path: &str) -> ConverterResult<ThingModel> {
-    SDFModel::deserialize_json_from_path(path).and_then(sdf_to_wot)
-}
-
-/// Deserializes a WoT Thing Model from a given file path and converts
-/// it into an SDF Model.
-///
-/// # Examples
-///
-/// ```rust
-/// use sdf_wot_converter::converter::wot_tm_to_sdf_from_path;
-///
-/// let result = wot_tm_to_sdf_from_path("examples/wot/example.tm.json");
-/// assert!(result.is_ok());
-///
-/// assert!(wot_tm_to_sdf_from_path("foobar.json").is_err());
-/// ```
-pub fn wot_tm_to_sdf_from_path(path: &str) -> ConverterResult<SDFModel> {
-    ThingModel::deserialize_json_from_path(path).and_then(wot_tm_to_sdf)
-}
-
-pub fn sdf_to_wot_from_and_to_path(input_path: &str, output_path: &str) -> ConverterResult<()> {
-    if !output_path.ends_with("tm.json") {
-        return Err("The output filename has to end with tm.json!".into());
-    }
-
-    sdf_to_wot_from_path(input_path).and_then(|x| x.write_json_to_path(output_path))
-}
-
-pub fn wot_tm_to_sdf_from_and_to_path(input_path: &str, output_path: &str) -> ConverterResult<()> {
-    if !output_path.ends_with("sdf.json") {
-        return Err("The output filename has to end with sdf.json!".into());
-    }
-
-    wot_tm_to_sdf_from_path(input_path).and_then(|x| x.write_json_to_path(output_path))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_sdf_to_wot() {
-        let output = sdf_to_wot(SDFModel::new_empty_model());
+        let output = sdf_to_wot_tm(SDFModel::new_empty_model());
         assert!(output.is_ok());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,10 +139,14 @@ mod tests {
     }
 
     #[test]
-    fn print_model_from_file_test() {
+    fn print_model_from_legal_path_test() {
         assert!(get_legal_inputs()
             .iter()
             .all(|f| print_model_from_file(f).is_ok()));
+    }
+
+    #[test]
+    fn print_model_from_illegal_path_test() {
         assert!(get_illegal_inputs()
             .iter()
             .all(|f| print_model_from_file(f).is_err()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use sdf_wot_converter::{converter, ConverterResult};
 
 use clap::{crate_authors, crate_version, App, Arg};
-use std::env;
+use std::{env, fs};
 // use url::Url;
 
 fn is_valid_input(input: String) -> Result<(), String> {
@@ -16,16 +16,34 @@ fn is_valid_input(input: String) -> Result<(), String> {
     }
 }
 
+fn get_json_from_file(path: &str) -> ConverterResult<String> {
+    fs::read_to_string(&path).map_err(|e| e.into())
+}
+
 fn print_model_from_file(path: &str) -> ConverterResult<()> {
+    let json_string = get_json_from_file(path)?;
     if path.ends_with("sdf.json") {
-        converter::print_sdf_definition_from_path(path)
+        converter::print_sdf_definition(json_string)
     } else if path.ends_with("td.json") {
-        converter::print_wot_td_definition_from_path(path)
+        converter::print_wot_td_definition(json_string)
     } else if path.ends_with("tm.json") {
-        converter::print_wot_tm_definition_from_path(path)
+        converter::print_wot_tm_definition(json_string)
     } else {
         Err("Illegal path ending!".into())
     }
+}
+
+fn convert_model_from_file_to_file(input_path: &str, output_path: &str) -> ConverterResult<()> {
+    let input_string = get_json_from_file(input_path)?;
+    let output_string: String;
+    if input_path.ends_with("sdf.json") {
+        output_string = converter::convert_sdf_to_wot_tm(input_string)?;
+    } else if input_path.ends_with("tm.json") {
+        output_string = converter::convert_wot_tm_to_sdf(input_string)?;
+    } else {
+        return Err("TD to SDF conversion is not implemented yet!".into());
+    }
+    fs::write(output_path, output_string).map_err(|e| e.into())
 }
 
 fn main() -> ConverterResult<()> {
@@ -72,19 +90,16 @@ fn main() -> ConverterResult<()> {
 
     if let Some(ref matches) = app.subcommand_matches("print") {
         if let Some(path) = matches.value_of("input") {
-            return print_model_from_file(path);
+            print_model_from_file(path)?
         }
     } else if let Some(ref matches) = app.subcommand_matches("convert") {
-        // TODO: Replace if-else with match
-        let input_path = matches.value_of("input").unwrap();
-        let output_path = matches.value_of("output").unwrap();
-        if input_path.ends_with("sdf.json") {
-            return converter::sdf_to_wot_from_and_to_path(input_path, output_path);
-        } else if input_path.ends_with("tm.json") {
-            return converter::wot_tm_to_sdf_from_and_to_path(input_path, output_path);
-        } else {
-            return Err("TD to SDF conversion is not implemented yet!".into());
-        }
+        let input_path = matches
+            .value_of("input")
+            .ok_or_else(|| "No input path found!".to_string())?;
+        let output_path = matches
+            .value_of("output")
+            .ok_or_else(|| "No output path found!".to_string())?;
+        convert_model_from_file_to_file(input_path, output_path)?
     }
 
     Ok(())

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,55 +1,24 @@
 use crate::ConverterResult;
-use std::fs;
-
-fn write_to_path(path: &str, content: String) -> ConverterResult<()> {
-    fs::write(path, content).map_err(|e| e.into())
-}
 
 /// Conveniance trait that is used to identify structs that implement serialization and
 /// deserialization capabilities provided by `serde`.
 pub trait SerializableModel: serde::Serialize + serde::de::DeserializeOwned {
-    fn path_is_valid(path: &str) -> bool;
-
     fn new_empty_model() -> Self;
 
     fn print(&self) -> ConverterResult<()> {
-        self.serialize_json().map(|j| println!("{}", j))
+        Self::serialize_json(self).map(|j| println!("{}", j))
     }
 
-    /// Deserializes a `SerializableModel`, converts it back into
-    /// a JSON string and prints it to the command line.
-    fn print_definition_from_path(path: &str) -> ConverterResult<()> {
-        Self::deserialize_json_from_path(path).and_then(|m| m.print())
+    fn print_definition(json_string: String) -> ConverterResult<()> {
+        let model = Self::deserialize_json_string(json_string)?;
+        model.print()
     }
 
-    /// Reads a JSON file from a specified path, deserializes it to a supported data type,
-    /// and returns an instance of the data type as a `Result`.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path of the JSON file you want to deserialize
-    ///
-    fn import_json_from_path(path: &str) -> ConverterResult<String> {
-        if !Self::path_is_valid(&path) {
-            return Err("Invalid input path given!".into());
-        }
-        fs::read_to_string(&path).map_err(|e| e.into())
-    }
-
-    fn serialize_json(&self) -> ConverterResult<String> {
-        serde_json::to_string_pretty(&self).map_err(|e| e.into())
+    fn serialize_json(model: &Self) -> ConverterResult<String> {
+        serde_json::to_string_pretty(&model).map_err(|e| e.into())
     }
 
     fn deserialize_json_string(json_string: String) -> ConverterResult<Self> {
         serde_json::from_str(json_string.as_str()).map_err(|e| e.into())
-    }
-
-    fn deserialize_json_from_path(path: &str) -> ConverterResult<Self> {
-        Self::import_json_from_path(path).and_then(Self::deserialize_json_string)
-    }
-
-    fn write_json_to_path(&self, path: &str) -> ConverterResult<()> {
-        self.serialize_json()
-            .and_then(|json_string| write_to_path(path, json_string))
     }
 }

--- a/src/sdf/definitions.rs
+++ b/src/sdf/definitions.rs
@@ -21,10 +21,6 @@ pub struct SDFModel {
 }
 
 impl SerializableModel for SDFModel {
-    fn path_is_valid(path: &str) -> bool {
-        path.ends_with("sdf.json")
-    }
-
     fn new_empty_model() -> SDFModel {
         SDFModel {
             info: None,

--- a/src/wot/definitions.rs
+++ b/src/wot/definitions.rs
@@ -107,10 +107,6 @@ fn get_empty_common_security() -> SecuritySchemeCommon {
 }
 
 impl SerializableModel for ThingDescription {
-    fn path_is_valid(path: &str) -> bool {
-        path.ends_with("td.json")
-    }
-
     fn new_empty_model() -> ThingDescription {
         let base_thing = get_empty_base_thing();
         let security = TypeOrTypeArray::Type("nosec_sc".to_string());
@@ -137,10 +133,6 @@ impl SerializableModel for ThingDescription {
 }
 
 impl SerializableModel for ThingModel {
-    fn path_is_valid(path: &str) -> bool {
-        path.ends_with("tm.json")
-    }
-
     fn new_empty_model() -> ThingModel {
         let base_thing = get_empty_base_thing();
 


### PR DESCRIPTION
This PR removes all file operations from the converter library itself and moves them to the `main.rs` file.